### PR TITLE
args refactor + link to paperless instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,44 @@ The files in this repository are mainly covered under the MIT-License.
 You need to have the DejaVu fonts available.
 
 On MacOS with brew:
+- `brew tap homebrew/cask-fonts`
+- `brew install font-dejavu`
 
-    brew tap homebrew/cask-fonts
-    brew install font-dejavu
+On Linux with apt:
+- `sudo apt install fonts-dejavu`
 
 # Usage
+## Init venv and activate
+`python3 -m venv .venv && . .venv/bin/activate`
 
-    # init venv and activate
-    python3 -m venv .venv && . .venv/bin/activate
+## Install requirements
+`pip install -r requirements`
 
-    # install requirements
-    pip install -r requirements
+## Arguments
+| Arg name        | Default   | Remarks                                                                                                                                                                                              |
+|-----------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  `--year`/`-y`  |     0     | Year can be omitted, default year is 0                                                                                                                                                               |
+| `--first`/`-f`  |     1     | First is the starting ASN and can be omitted, default start is 1                                                                                                                                     |
+| `--last`/`-l`   |           | Last is the last ASN to generate. It can either be an integer or a value starting with 'x' like 'x3' which means to generate 3 blocks of 16 labels. If omitted, a full sheet of labels is generated. |
+| `--url`/`-u`    | ASNxxxxxx | paperless-ngx instance url, ex: `http://192.168.10.1:5000`. If set, the generated QR code will point to that specific document. If not set, the default ASN will be used                             |
+| `--output`/`-o` |           | The name of the pdf to generate, default 'output.pdf'                                                                                                                                                |
 
-    # generate labels for year 2023, start at 1, create 16x2 labels
-    ./gen-asn.py :81:x3 23:1:x2
+## Generate labels
+generate labels for year 2024, start at 1
 
-    # see gen-asn.py --help for more details
-    ./gen-asn.py --help
+`./gen-asn.py --year 24 --first 1`
+
+generate labels for year 2024, start at 1, specifying paperless-ngx instance
+
+`./gen-asn.py --year 24 --first 1 --url http://192.168.1.1:5000`
+
+## Help
+see gen-asn.py --help for more details
+
+`./gen-asn.py --help`
+
+## Paperless-ngx
+
+It is possible to make [paperless-ngx](https://docs.paperless-ngx.com/) automatically recognize the ASN from the label and associate it with the document. To do this follow the paperless-ngx [documentation](https://docs.paperless-ngx.com/advanced_usage/#barcodes)
+
+Remember to set the correct prefix. If you use the url option use: `<url>/documents?archive_serial_number=`, for example: `http://192.168.10.1:5000/documents?archive_serial_number=`, otherwise `ASN`.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ On Linux with apt:
 `pip install -r requirements`
 
 ## Arguments
+
 | Arg name        | Default   | Remarks                                                                                                                                                                                              |
 |-----------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--rows`/`-r`   |     16    | number of rows, default is 16                                                                                                                                                                        |
+| `--cols`/`-c`   |     5     | number of columns, default is 5                                                                                                                                                                      |
 |  `--year`/`-y`  |     0     | Year can be omitted, default year is 0                                                                                                                                                               |
 | `--first`/`-f`  |     1     | First is the starting ASN and can be omitted, default start is 1                                                                                                                                     |
 | `--last`/`-l`   |           | Last is the last ASN to generate. It can either be an integer or a value starting with 'x' like 'x3' which means to generate 3 blocks of 16 labels. If omitted, a full sheet of labels is generated. |
 | `--url`/`-u`    | ASNxxxxxx | paperless-ngx instance url, ex: `http://192.168.10.1:5000`. If set, the generated QR code will point to that specific document. If not set, the default ASN will be used                             |
 | `--output`/`-o` |           | The name of the pdf to generate, default 'output.pdf'                                                                                                                                                |
+
 
 ## Generate labels
 generate labels for year 2024, start at 1

--- a/gen-asn.py
+++ b/gen-asn.py
@@ -46,15 +46,9 @@ colors = [
 ]
 
 
-# sheet config
-ROWS = 16
-COLS = 5
-CELLS = ROWS*COLS
-
-
 def my_url(arg):
     url = urlparse(arg)
-    if all((url.scheme, url.netloc)):  # possibly other sections?
+    if all((url.scheme, url.netloc)):
         return f"{url.scheme}://{url.netloc}"
     raise ArgumentTypeError('Invalid URL')
 
@@ -62,10 +56,10 @@ def my_url(arg):
 def parse_cfg(args):
     if not args.last:
         # generate one page full of labels
-        last = args.first + ROWS * COLS - 1
+        last = args.first + args.rows * args.cols - 1
     elif args.last.startswith("x"):
         # generate n columns of labels
-        last = args.first + ROWS * int(args.last[1:]) - 1
+        last = args.first + args.rows * int(args.last[1:]) - 1
     else:
         # generate labels from first-last
         last = int(args.last)
@@ -121,6 +115,22 @@ def main():
     parser = argparse.ArgumentParser(description='Generate ASN')
 
     parser.add_argument(
+        '--rows',
+        '-r',
+        default=16,
+        type=int,
+        help=f"Rows can be omitted, default rows is 16."
+    )
+
+    parser.add_argument(
+        '--cols',
+        '-c',
+        default=5,
+        type=int,
+        help=f"Cols can be omitted, default cols is 5."
+    )
+
+    parser.add_argument(
         '--year',
         '-y',
         default=0,
@@ -140,12 +150,12 @@ def main():
         '--last',
         '-l', 
         help=f"""Last is the last ASN to generate. It can either be an integer or a value starting with 'x' like 'x3' which means to 
-        generate 3 blocks of {ROWS} labels. If omitted, a full sheet of labels is generated."""
+        generate 3 blocks of labels. If omitted, a full sheet of labels is generated."""
     )
     
     parser.add_argument(
-        "-u",
         "--url",
+        "-u",
         type=my_url,
         help="Paperless-ngx instance url, ex: `http://192.168.10.1:5000`. If set, the generated QR code will point to that specific document. If not set, the default ASN will be used",
     )
@@ -179,4 +189,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-L

--- a/gen-asn.py
+++ b/gen-asn.py
@@ -147,7 +147,7 @@ def main():
         "-u",
         "--url",
         type=my_url,
-        help="aperless-ngx instance url, ex: `http://192.168.10.1:5000`. If set, the generated QR code will point to that specific document. If not set, the default ASN will be used",
+        help="Paperless-ngx instance url, ex: `http://192.168.10.1:5000`. If set, the generated QR code will point to that specific document. If not set, the default ASN will be used",
     )
 
     parser.add_argument(
@@ -160,8 +160,6 @@ def main():
     )
 
     args = parser.parse_args()
-
-    print(args)
 
     (year, first, last) = parse_cfg(args)
     data = [[year, x] for x in range(first, last+1)]
@@ -181,3 +179,4 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+L

--- a/gen-asn.py
+++ b/gen-asn.py
@@ -62,10 +62,10 @@ def my_url(arg):
 def parse_cfg(args):
     if not args.last:
         # generate one page full of labels
-        last = first + ROWS * COLS - 1
+        last = args.first + ROWS * COLS - 1
     elif args.last.startswith("x"):
         # generate n columns of labels
-        last = first + ROWS * int(args.last[1:]) - 1
+        last = args.first + ROWS * int(args.last[1:]) - 1
     else:
         # generate labels from first-last
         last = int(args.last)
@@ -160,6 +160,8 @@ def main():
     )
 
     args = parser.parse_args()
+
+    print(args)
 
     (year, first, last) = parse_cfg(args)
     data = [[year, x] for x in range(first, last+1)]

--- a/gen-asn.py
+++ b/gen-asn.py
@@ -147,7 +147,7 @@ def main():
         "-u",
         "--url",
         type=my_url,
-        help="foobar",
+        help="aperless-ngx instance url, ex: `http://192.168.10.1:5000`. If set, the generated QR code will point to that specific document. If not set, the default ASN will be used",
     )
 
     parser.add_argument(


### PR DESCRIPTION
- Rewrote the arg parser for a simpler configuration
- Added the option to reach the document on paperless by scanning the QR (need to change paperless settings)
- Modified Readme adding new options and command to install the font on Linux